### PR TITLE
Additional metrics and bug fixes

### DIFF
--- a/prometheus/config.go
+++ b/prometheus/config.go
@@ -4,21 +4,26 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var defaultBuckets = prometheus.ExponentialBuckets(0.005, 2, 8)
+var (
+	defaultBuckets         = prometheus.ExponentialBuckets(0.005, 2, 8)
+	defaultMgetKeysBuckets = []float64{50, 100, 200, 500, 1000, 2000, 4000, 8000, 16000}
+)
 
 type config struct {
-	namespace    string
-	subSystem    string
-	globalLabels map[string]string
-	buckets      []float64
+	namespace       string
+	subSystem       string
+	globalLabels    map[string]string
+	buckets         []float64
+	mgetKeysBuckets []float64
 }
 
 func newConfig() *config {
 	return &config{
-		namespace:    "redis",
-		subSystem:    "cache",
-		globalLabels: make(map[string]string),
-		buckets:      defaultBuckets,
+		namespace:       "redis",
+		subSystem:       "cache",
+		globalLabels:    make(map[string]string),
+		buckets:         defaultBuckets,
+		mgetKeysBuckets: defaultMgetKeysBuckets,
 	}
 }
 
@@ -49,5 +54,13 @@ func WithConstLabels(labels map[string]string) Option {
 func WithBuckets(buckets []float64) Option {
 	return func(c *config) {
 		c.buckets = buckets
+	}
+}
+
+// WithMGETKeysBuckets overrides the default buckets used for the Prometheus
+// histogram that tracks the number of keys requested in MGET commands
+func WithMGETKeysBuckets(buckets []float64) Option {
+	return func(c *config) {
+		c.mgetKeysBuckets = buckets
 	}
 }

--- a/version.go
+++ b/version.go
@@ -2,5 +2,5 @@ package cache
 
 // Version returns the current version of redis-cache.
 func Version() string {
-	return "1.5.0"
+	return "1.5.1"
 }


### PR DESCRIPTION
Adds a new prometheus metric to track how many keys are being requested for MGET operations. This can be useful to understand how much pressure may be put against the Redis proxy when running in Enterprise Clustering, or how much pressure will be put on the nodes when not running in OSS clustering policy.

Fixes a bug where Prometheus cache hits metric was being incremented when there was a cache miss.

Moves the version to 1.5.1